### PR TITLE
Support multi repository with branch names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 node_modules/
 .vscode-test/
 *.vsix
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the "promptitude" extension will be documented in this file.
 
+## [1.3.0] - 2025-09-25
+
+### Changed
+
+- Configuration now supports per-repository branch selection via `promptitude.repositories` entries in the form `https://github.com/owner/repo|branch`.
+- **Breaking** Removed the separate `promptitude.branch` setting. If no branch is provided for an entry, `main` is used by default.
+
 ## [1.2.0] - 2025-09-22
 
 - Renamed extension to promptitude for better visibility on vscode extensions marketplace.

--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ The Prompts Sync Extension automatically synchronizes the latest GitHub Copilot 
 | `promptitude.enabled`           | Enable/disable automatic syncing | `true`                                                               | boolean |
 | `promptitude.frequency`         | Sync frequency                   | `"daily"`                                                            | string  |
 | `promptitude.customPath`        | Custom prompts directory path    | `""`                                                                 | string  |
-| `promptitude.repositories`      | List of repository URLs          | `[]`                                                                 | array   |
-| `promptitude.branch`            | Repository branch to sync        | `"main"`                                                             | string  |
+| `promptitude.repositories`      | Repositories with optional branch (use `url` or `url|branch`) | `[]`                                                                 | array   |
 | `promptitude.syncOnStartup`     | Sync when VS Code starts         | `true`                                                               | boolean |
 | `promptitude.showNotifications` | Show sync status notifications   | `true`                                                               | boolean |
 | `promptitude.syncChatmode`      | Sync chatmode prompts            | `true`                                                               | boolean |
@@ -81,22 +80,24 @@ You can override this by setting a custom path in `promptitude.customPath`.
 
 The extension supports syncing from multiple Git repositories simultaneously. This is useful for organizations that maintain prompt collections across multiple repositories or for users who want to combine prompts from different sources.
 
-#### Setting up Multiple Repositories
+#### Setting up Multiple Repositories (with optional per-repo branch)
 
 1. **Using VS Code Settings UI**:
    - Open Settings (`Ctrl+,` or `Cmd+,`)
-   - Search for "promptitude.repositories"
-   - Click "Add Item" to add each repository URL
+    - Search for "promptitude.repositories"
+    - Click "Add Item" to add each repository using one of the following formats:
+       - `https://github.com/your-org/prompts` (defaults to branch `main`)
+       - `https://github.com/your-org/prompts|develop` (explicit branch)
 
 2. **Using JSON Configuration**:
    ```json
-   {
-     "promptitude.repositories": [
-       "https://github.com/your-org/prompts-main",
-       "https://github.com/your-org/prompts-experimental",
-       "https://github.com/another-org/shared-prompts"
-     ]
-   }
+    {
+       "promptitude.repositories": [
+          "https://github.com/your-org/prompts",
+          "https://github.com/your-org/prompts|develop",
+          "https://github.com/another-org/shared-prompts|release"
+       ]
+    }
    ```
 
 #### Error Handling
@@ -268,35 +269,9 @@ We welcome contributions to improve the extension! Please see our [Contribution 
 
 ## 📋 Changelog
 
-### Version 1.2.0 (Multiple Repository Support)
+For the complete release history, detailed changes, and migration notes, please refer to the project's changelog:
 
-- ✅ **New Feature**: Support for syncing from multiple Git repositories
-- ✅ Added `promptitude.repositories` array setting for multiple repository URLs
-- ✅ Enhanced error handling for repository conflicts and failures
-- ✅ Improved status display showing multi-repository sync results
-- ✅ Graceful handling of partial sync success scenarios
-- ✅ Backward compatibility with single repository configuration
-- ✅ Updated documentation with multi-repository setup instructions
-
-### Version 1.1.0 (Selective Sync & Flattened Structure)
-
-- ✅ **New Feature**: Selective sync settings for different prompt types
-- ✅ Added `promptitude.syncChatmode` setting (default: true)
-- ✅ Added `promptitude.syncInstructions` setting (default: true)
-- ✅ Added `promptitude.syncPrompt` setting (default: true)
-- ✅ Flattened folder structure - all files sync directly to `User/prompts/`
-- ✅ Enhanced status display showing selected sync types
-- ✅ Improved configurability and user control
-
-### Version 1.0.0 (Initial Release)
-
-- ✅ Basic sync functionality
-- ✅ Configurable sync frequency
-- ✅ Cross-platform support
-- ✅ GitHub authentication integration
-- ✅ Status bar integration
-- ✅ User notifications
-- ✅ Manual sync commands
+[See CHANGELOG.md](./CHANGELOG.md)
 
 ## 📄 License
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "promptitude-extension",
   "displayName": "Promptitude",
   "description": "Sync GitHub Copilot prompts, chatmodes and instructions from git repositories",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "publisher": "logientnventive",
   "repository": {
     "type": "git",
@@ -50,15 +50,10 @@
           "items": {
             "type": "string"
           },
-          "default": ["https://github.com/github/awesome-copilot"],
-          "description": "List of repository URLs to sync from",
+          "default": [],
+          "markdownDescription": "Repositories to sync, with optional per-repo branch using the format `https://github.com/owner/repo|branch`. If no branch is specified, `main` is used.\n\nExamples:\n- `https://github.com/org/prompt-repo` (uses `main`)\n- `https://github.com/org/prompt-repo|develop`",
+          "description": "Repositories to sync. Use format: https://github.com/owner/repo or https://github.com/owner/repo|branch",
           "order": 0
-        },
-        "promptitude.branch": {
-          "type": "string",
-          "default": "main",
-          "description": "Repository branch to sync",
-          "order": 10
         },
         "promptitude.syncOnStartup": {
           "type": "boolean",

--- a/src/syncManager.ts
+++ b/src/syncManager.ts
@@ -179,7 +179,7 @@ export class SyncManager {
             try {
                 content = await this.github.getFileContent(owner, repo, file.path, branch);
             } catch (error) {
-                // An error occured will retrieving file content, Return here
+                // An error occurred while retrieving file content, Return here
                 this.logger.warn(`Failed to fetch content for ${file.path}: ${error}`);
                 this.notifications.showSyncError(`Failed to fetch content for ${file.path} branch:${branch}: ${error}.`);
                 return itemsUpdated;

--- a/src/syncManager.ts
+++ b/src/syncManager.ts
@@ -166,7 +166,7 @@ export class SyncManager {
         });
     }
 
-    private async syncFiles(owner: string, repo: string, files: GitHubTreeItem[]): Promise<number> {
+    private async syncFiles(owner: string, repo: string, files: GitHubTreeItem[], branch: string): Promise<number> {
         const promptsDir = this.config.getPromptsDirectory();
         await this.fileSystem.ensureDirectoryExists(promptsDir);
         
@@ -177,11 +177,11 @@ export class SyncManager {
             let content = null;
 
             try {
-                content = await this.github.getFileContent(owner, repo, file.path, this.config.branch);
+                content = await this.github.getFileContent(owner, repo, file.path, branch);
             } catch (error) {
                 // An error occured will retrieving file content, Return here
                 this.logger.warn(`Failed to fetch content for ${file.path}: ${error}`);
-                this.notifications.showSyncError(`Failed to fetch content for ${file.path}: ${error}. Make sure that the correct is set. Current branch: ${this.config.branch}`);
+                this.notifications.showSyncError(`Failed to fetch content for ${file.path} branch:${branch}: ${error}.`);
                 return itemsUpdated;
             }
 
@@ -219,16 +219,20 @@ export class SyncManager {
         let totalItemsUpdated = 0;
         const errors: string[] = [];
 
-        for (const repoUrl of repositories) {
+        const repoConfigs = this.config.repositoryConfigs;
+
+        for (const entry of repoConfigs) {
+            const repoUrl = entry.url;
+            const branch = entry.branch;
             try {
                 this.logger.debug(`Syncing repository: ${repoUrl}`);
                 
                 // Parse repository URL
                 const { owner, repo } = this.github.parseRepositoryUrl(repoUrl);
-                this.logger.debug(`Syncing from ${owner}/${repo} branch ${this.config.branch}`);
+                this.logger.debug(`Syncing from ${owner}/${repo} branch ${branch}`);
 
                 // Get repository tree
-                const tree = await this.github.getRepositoryTree(owner, repo, this.config.branch);
+                const tree = await this.github.getRepositoryTree(owner, repo, branch);
                 this.logger.debug(`Retrieved repository tree with ${tree.tree.length} items for ${repoUrl}`);
 
                 // Filter relevant files
@@ -249,7 +253,7 @@ export class SyncManager {
                 this.logger.debug(`Found ${relevantFiles.length} relevant files to sync for ${repoUrl}`);
 
                 // Sync files
-                const itemsUpdated = await this.syncFiles(owner, repo, relevantFiles);
+                const itemsUpdated = await this.syncFiles(owner, repo, relevantFiles, branch);
                 
                 results.push({
                     repository: repoUrl,
@@ -338,13 +342,14 @@ export class SyncManager {
         }
 
         const repositories = this.config.repositories;
+        const repoConfigs = this.config.repositoryConfigs;
         
         const items = [
             'Sync Status',
             '──────────',
             `Enabled: ${this.config.enabled ? '✅' : '❌'}`,
             `Frequency: ${this.config.frequency}`,
-            `Branch: ${this.config.branch}`,
+            `Branches: ${repoConfigs.length > 0 ? repoConfigs.map(rc => rc.branch).join(', ') : 'main'}`,
             `Prompts Directory: ${this.config.getPromptsDirectory()}`,
             `Sync on Startup: ${this.config.syncOnStartup ? '✅' : '❌'}`,
             `Show Notifications: ${this.config.showNotifications ? '✅' : '❌'}`,
@@ -356,8 +361,8 @@ export class SyncManager {
         ];
 
         // Add each repository
-        repositories.forEach((repo, index) => {
-            items.push(`${index + 1}. ${repo}`);
+        repoConfigs.forEach((rc, index) => {
+            items.push(`${index + 1}. ${rc.url} (branch: ${rc.branch})`);
         });
 
         items.push(


### PR DESCRIPTION
This pull request introduces a breaking change that improves repository configuration by allowing per-repository branch selection and removes the now useless global branch setting. 

 If no branch is specified, `main` is used by default.
