### PR TITLE
feat: Add command to open prompts folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,11 @@
         "command": "promptitude.showStatus",
         "title": "Show Status",
         "category": "Promptitude"
+      },
+      {
+        "command": "promptitude.openPromptsFolder",
+        "title": "Open Prompts Folder",
+        "category": "Promptitude"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,9 +25,14 @@ export function activate(context: vscode.ExtensionContext) {
         await syncManager.showStatus();
     });
 
+    const openPromptsFolderCommand = vscode.commands.registerCommand('promptitude.openPromptsFolder', async () => {
+        await syncManager.openPromptsFolder();
+    });
+
     // Add to subscriptions
     context.subscriptions.push(syncNowCommand);
     context.subscriptions.push(showStatusCommand);
+    context.subscriptions.push(openPromptsFolderCommand);
     context.subscriptions.push(statusBarManager);
 
     // Initialize sync manager

--- a/src/syncManager.ts
+++ b/src/syncManager.ts
@@ -408,7 +408,6 @@ export class SyncManager {
             this.logger.info(`Opened prompts folder: ${promptsDir}`);
             
             // Show info message
-            await this.notifications.showInfo(`Opened prompts folder: ${promptsDir}`);
             
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/src/syncManager.ts
+++ b/src/syncManager.ts
@@ -394,6 +394,29 @@ export class SyncManager {
         quickPick.show();
     }
 
+    async openPromptsFolder(): Promise<void> {
+        try {
+            const promptsDir = this.config.getPromptsDirectory();
+            
+            // Ensure directory exists
+            await this.fileSystem.ensureDirectoryExists(promptsDir);
+            
+            // Open folder in system file explorer
+            const folderUri = vscode.Uri.file(promptsDir);
+            await vscode.commands.executeCommand('revealFileInOS', folderUri);
+            
+            this.logger.info(`Opened prompts folder: ${promptsDir}`);
+            
+            // Show info message
+            await this.notifications.showInfo(`Opened prompts folder: ${promptsDir}`);
+            
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            this.logger.error('Failed to open prompts folder', error instanceof Error ? error : undefined);
+            await this.notifications.showError(`Failed to open prompts folder: ${errorMessage}`);
+        }
+    }
+
     dispose(): void {
         this.logger.info('Disposing SyncManager...');
         


### PR DESCRIPTION
This pull request introduces a new command to the Promptitude extension that allows users to quickly open the prompts folder in their system file explorer. The main changes involve registering the new command, implementing its logic, and updating the extension's command list.

**New command for opening prompts folder:**

* Added a new command `promptitude.openPromptsFolder` to the `package.json` command list, making it available in the extension's UI.
* Registered the `promptitude.openPromptsFolder` command in `src/extension.ts` and ensured it is properly disposed of with other subscriptions.

**Command implementation:**

* Implemented the `openPromptsFolder` method in `SyncManager` (`src/syncManager.ts`), which ensures the prompts directory exists, opens it in the system file explorer, logs the action, and provides user feedback via notifications. Error handling is included to inform the user if the folder cannot be opened.